### PR TITLE
Updating for Commons Collections4

### DIFF
--- a/jung-extensions/.classpath
+++ b/jung-extensions/.classpath
@@ -1,18 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="src" path="src/test/java" output="target/test-classes" including="**/*.java"/>
-  <classpathentry kind="src" path="src/test/resources" output="target/test-classes" excluding="**/*.java"/>
-  <classpathentry kind="src" path="src/main/java" including="**/*.java"/>
-  <classpathentry kind="src" path="src/main/resources" excluding="**/*.java"/>
-  <classpathentry kind="output" path="target/classes"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-  <classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-api/2.0.1/jung-api-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-api/2.0.1/jung-api-2.0.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/net/sourceforge/collections/collections-generic/4.01/collections-generic-4.01.jar" sourcepath="M2_REPO/net/sourceforge/collections/collections-generic/4.01/collections-generic-4.01-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-algorithms/2.0.1/jung-algorithms-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-algorithms/2.0.1/jung-algorithms-2.0.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/colt/colt/1.2.0/colt-1.2.0.jar"/>
-  <classpathentry kind="var" path="M2_REPO/concurrent/concurrent/1.3.4/concurrent-1.3.4.jar" sourcepath="M2_REPO/concurrent/concurrent/1.3.4/concurrent-1.3.4-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-visualization/2.0.1/jung-visualization-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-visualization/2.0.1/jung-visualization-2.0.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/junit/junit/4.8.2/junit-4.8.2.jar" sourcepath="M2_REPO/junit/junit/4.8.2/junit-4.8.2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-graph-impl/2.0.1/jung-graph-impl-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-graph-impl/2.0.1/jung-graph-impl-2.0.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/mockito/mockito-all/1.9.5-rc1/mockito-all-1.9.5-rc1.jar" sourcepath="M2_REPO/org/mockito/mockito-all/1.9.5-rc1/mockito-all-1.9.5-rc1-sources.jar"/>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**/*.java" kind="src" output="target/test-classes" path="src/test/resources"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**/*.java" kind="src" path="src/main/resources"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-api/2.0.1/jung-api-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-api/2.0.1/jung-api-2.0.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-algorithms/2.0.1/jung-algorithms-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-algorithms/2.0.1/jung-algorithms-2.0.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/colt/colt/1.2.0/colt-1.2.0.jar"/>
+	<classpathentry kind="var" path="M2_REPO/concurrent/concurrent/1.3.4/concurrent-1.3.4.jar" sourcepath="M2_REPO/concurrent/concurrent/1.3.4/concurrent-1.3.4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-visualization/2.0.1/jung-visualization-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-visualization/2.0.1/jung-visualization-2.0.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/junit/junit/4.8.2/junit-4.8.2.jar" sourcepath="M2_REPO/junit/junit/4.8.2/junit-4.8.2-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/jung/jung-graph-impl/2.0.1/jung-graph-impl-2.0.1.jar" sourcepath="M2_REPO/net/sf/jung/jung-graph-impl/2.0.1/jung-graph-impl-2.0.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/mockito/mockito-all/1.9.5-rc1/mockito-all-1.9.5-rc1.jar" sourcepath="M2_REPO/org/mockito/mockito-all/1.9.5-rc1/mockito-all-1.9.5-rc1-sources.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/EdgeCommunityClustererTransformer.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/EdgeCommunityClustererTransformer.java
@@ -12,7 +12,7 @@ import net.stuarthendren.jung.cluster.edge.impl.EdgePartitionDensityTransformer;
 import net.stuarthendren.jung.partition.Partition;
 import net.stuarthendren.jung.partition.impl.PartitionImpl;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/GraphEdgeCommunityClustererTransformer.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/GraphEdgeCommunityClustererTransformer.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 import net.stuarthendren.jung.cluster.edge.impl.EdgeDendogramUtils;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/impl/EdgePartitionDensityTransformer.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/impl/EdgePartitionDensityTransformer.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import net.stuarthendren.jung.partition.Partition;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.graph.Graph;
 

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/impl/EdgeSimilarityTransformer.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/edge/impl/EdgeSimilarityTransformer.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.cluster.edge.impl;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.UndirectedGraph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/metric/Conductance.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/metric/Conductance.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.cluster.metric;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.graph.Graph;
 

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/metric/Expansion.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/metric/Expansion.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.cluster.metric;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.graph.Graph;
 

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/vertex/flow/DelegatingCutClusterGraph.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/cluster/vertex/flow/DelegatingCutClusterGraph.java
@@ -9,7 +9,7 @@ import java.util.Map.Entry;
 
 import net.stuarthendren.jung.graph.DelegatingGraph;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.graph.DirectedGraph;
 import edu.uci.ics.jung.graph.util.EdgeType;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/element/IntegerFactory.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/element/IntegerFactory.java
@@ -1,6 +1,7 @@
 package net.stuarthendren.jung.element;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
+
 
 public class IntegerFactory implements Factory<Integer> {
 

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/AbstractInducedGraph.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/AbstractInducedGraph.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.graph;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.commons.collections15.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.util.EdgeType;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/CompleteGraph.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/CompleteGraph.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.graph;
 import net.stuarthendren.jung.element.IntegerFactory;
 import net.stuarthendren.jung.graph.generator.CompleteGraphGenerator;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/PlantedPartitionGraph.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/PlantedPartitionGraph.java
@@ -5,7 +5,7 @@ import java.util.Random;
 import net.stuarthendren.jung.element.IntegerFactory;
 import net.stuarthendren.jung.graph.generator.PlantedPartitionGraphGenerator;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/RandomGraph.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/RandomGraph.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.graph;
 import net.stuarthendren.jung.element.IntegerFactory;
 import net.stuarthendren.jung.graph.generator.RandomGraphGenerator;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/RelaxedCavemanGraph.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/RelaxedCavemanGraph.java
@@ -3,7 +3,7 @@ package net.stuarthendren.jung.graph;
 import net.stuarthendren.jung.element.IntegerFactory;
 import net.stuarthendren.jung.graph.generator.RelaxedCavemanGraphGenerator;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/CompleteGraphGenerator.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/CompleteGraphGenerator.java
@@ -2,7 +2,7 @@ package net.stuarthendren.jung.graph.generator;
 
 import java.util.Collection;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.algorithms.generators.GraphGenerator;
 import edu.uci.ics.jung.graph.Graph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/PlantedPartitionGraphGenerator.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/PlantedPartitionGraphGenerator.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.algorithms.generators.GraphGenerator;
 import edu.uci.ics.jung.graph.Graph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/RandomGraphGenerator.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/RandomGraphGenerator.java
@@ -5,7 +5,7 @@ import java.util.Random;
 import net.stuarthendren.jung.utils.UnorderedPair;
 import net.stuarthendren.jung.utils.UnorderedPairs;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.algorithms.generators.GraphGenerator;
 import edu.uci.ics.jung.graph.Graph;

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/RelaxedCavemanGraphGenerator.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/graph/generator/RelaxedCavemanGraphGenerator.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import org.apache.commons.collections15.Factory;
+import org.apache.commons.collections4.Factory;
 
 import edu.uci.ics.jung.algorithms.generators.GraphGenerator;
 import edu.uci.ics.jung.graph.Graph;
@@ -106,8 +106,6 @@ public class RelaxedCavemanGraphGenerator<V, E> implements GraphGenerator<V, E> 
 
 	private void replace(Graph<V, E> graph, V vertex, Graph<V, E> cave) {
 		Map<V, V> newVertices = new HashMap<V, V>();
-		int baseVerticies = graph.getVertexCount();
-		int baseEdges = graph.getEdgeCount();
 		int caveSize = cave.getVertexCount();
 		Iterator<V> iterator = cave.getVertices().iterator();
 		// Map first to original vertex

--- a/jung-extensions/src/main/java/net/stuarthendren/jung/visualization/GraphViewer.java
+++ b/jung-extensions/src/main/java/net/stuarthendren/jung/visualization/GraphViewer.java
@@ -7,7 +7,7 @@ import java.awt.event.KeyEvent;
 
 import javax.swing.JFrame;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 import edu.uci.ics.jung.algorithms.layout.FRLayout;
 import edu.uci.ics.jung.algorithms.layout.Layout;
@@ -48,7 +48,7 @@ public class GraphViewer {
 				if (vv.getPickedVertexState().isPicked(v)) {
 					return Color.cyan;
 				} else {
-					return Color.BLACK;
+					return Color.black;
 				}
 			}
 		});

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/EdgeCommunityClustererDendogramTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/EdgeCommunityClustererDendogramTest.java
@@ -1,13 +1,12 @@
 package net.stuarthendren.jung.cluster.edge;
 
+import static org.junit.Assert.assertEquals;
 import net.stuarthendren.jung.cluster.edge.impl.EdgeDendogramUtils;
 import net.stuarthendren.jung.dendrogram.Dendrogram;
 import net.stuarthendren.jung.dendrogram.partition.impl.AbstractEdgeClusterTest;
 import net.stuarthendren.jung.partition.Partition;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class EdgeCommunityClustererDendogramTest extends AbstractEdgeClusterTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/EdgeCommunityClustererTransformerTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/EdgeCommunityClustererTransformerTest.java
@@ -1,19 +1,19 @@
 package net.stuarthendren.jung.cluster.edge;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 import java.util.Set;
 
 import net.stuarthendren.jung.dendrogram.partition.impl.AbstractEdgeClusterTest;
 import net.stuarthendren.jung.graph.CompleteGraph;
 
-import org.apache.commons.collections15.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class EdgeCommunityClustererTransformerTest extends AbstractEdgeClusterTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/EdgeSimilarityTransformerTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/EdgeSimilarityTransformerTest.java
@@ -1,5 +1,6 @@
 package net.stuarthendren.jung.cluster.edge;
 
+import static org.junit.Assert.assertEquals;
 import net.stuarthendren.jung.cluster.edge.impl.EdgeSimilarityTransformer;
 import net.stuarthendren.jung.cluster.edge.impl.KeyedEdgePair;
 
@@ -7,8 +8,6 @@ import org.junit.Test;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * These tests are based on the similarity examples in Figure S1 of the paper (see {@link EdgeCommunityClusterer}).

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/GraphEdgeCommunityClustererTransformerTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/GraphEdgeCommunityClustererTransformerTest.java
@@ -1,19 +1,19 @@
 package net.stuarthendren.jung.cluster.edge;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 import java.util.Set;
 
 import net.stuarthendren.jung.dendrogram.partition.impl.AbstractEdgeClusterTest;
 import net.stuarthendren.jung.graph.CompleteGraph;
 
-import org.apache.commons.collections15.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class GraphEdgeCommunityClustererTransformerTest extends AbstractEdgeClusterTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/KeyedEdgeCommunityClustererDendogramTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/edge/KeyedEdgeCommunityClustererDendogramTest.java
@@ -1,13 +1,12 @@
 package net.stuarthendren.jung.cluster.edge;
 
+import static org.junit.Assert.assertEquals;
 import net.stuarthendren.jung.cluster.edge.impl.EdgeDendogramUtils;
 import net.stuarthendren.jung.dendrogram.graph.GraphDendrogram;
 import net.stuarthendren.jung.dendrogram.graph.impl.KeyedDendrogram;
 import net.stuarthendren.jung.dendrogram.partition.impl.AbstractEdgeClusterTest;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class KeyedEdgeCommunityClustererDendogramTest extends AbstractEdgeClusterTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/metric/ConductanceTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/metric/ConductanceTest.java
@@ -1,14 +1,15 @@
 package net.stuarthendren.jung.cluster.metric;
 
+import static junit.framework.Assert.assertEquals;
+
 import java.util.Collections;
 
 import net.stuarthendren.jung.graph.CompleteGraph;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-import static junit.framework.Assert.assertEquals;
 
 public class ConductanceTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/metric/ExpansionTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/cluster/metric/ExpansionTest.java
@@ -1,14 +1,15 @@
 package net.stuarthendren.jung.cluster.metric;
 
+import static junit.framework.Assert.assertEquals;
+
 import java.util.Collections;
 
 import net.stuarthendren.jung.graph.CompleteGraph;
 
-import org.apache.commons.collections15.Transformer;
+import org.apache.commons.collections4.Transformer;
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-import static junit.framework.Assert.assertEquals;
 
 public class ExpansionTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/dendrogram/graph/impl/KeyedDendrogramTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/dendrogram/graph/impl/KeyedDendrogramTest.java
@@ -8,11 +8,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import net.stuarthendren.jung.dendrogram.graph.DendrogramNode;
-import net.stuarthendren.jung.dendrogram.graph.impl.KeyedDendrogram;
-import net.stuarthendren.jung.dendrogram.graph.impl.KeyedDendrogramNode;
-import net.stuarthendren.jung.dendrogram.graph.impl.LeafDendrogramNode;
 
-import org.apache.commons.collections15.comparators.ComparableComparator;
+import org.apache.commons.collections4.comparators.ComparableComparator;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/AbstractInducedGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/AbstractInducedGraphTest.java
@@ -1,11 +1,17 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.collections15.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,11 +19,6 @@ import org.junit.Test;
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.util.EdgeType;
 import edu.uci.ics.jung.graph.util.Pair;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
 
 public abstract class AbstractInducedGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/BackedInducedGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/BackedInducedGraphTest.java
@@ -1,11 +1,12 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertEquals;
+
 import java.util.Set;
 
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-import static junit.framework.Assert.assertEquals;
 
 public class BackedInducedGraphTest extends AbstractInducedGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/CompleteGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/CompleteGraphTest.java
@@ -1,13 +1,13 @@
 package net.stuarthendren.jung.graph;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Collection;
 
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class CompleteGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/GraphUtilsTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/GraphUtilsTest.java
@@ -1,5 +1,8 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,8 +12,6 @@ import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.SparseGraph;
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.util.EdgeType;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 
 public class GraphUtilsTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/PlantedPartitionGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/PlantedPartitionGraphTest.java
@@ -1,10 +1,11 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertEquals;
+
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.util.Pair;
-import static junit.framework.Assert.assertEquals;
 
 public class PlantedPartitionGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/RandomGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/RandomGraphTest.java
@@ -1,9 +1,10 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertEquals;
+
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-import static junit.framework.Assert.assertEquals;
 
 public class RandomGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/RelaxedCavemanGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/RelaxedCavemanGraphTest.java
@@ -1,10 +1,10 @@
 package net.stuarthendren.jung.graph;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-
-import static org.junit.Assert.assertTrue;
 
 public class RelaxedCavemanGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/StaticInducedGraphTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/StaticInducedGraphTest.java
@@ -1,11 +1,12 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertEquals;
+
 import java.util.Set;
 
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
-import static junit.framework.Assert.assertEquals;
 
 public class StaticInducedGraphTest extends AbstractInducedGraphTest {
 

--- a/jung-extensions/src/test/java/net/stuarthendren/jung/graph/UndirectedGraphWrapperTest.java
+++ b/jung-extensions/src/test/java/net/stuarthendren/jung/graph/UndirectedGraphWrapperTest.java
@@ -1,13 +1,14 @@
 package net.stuarthendren.jung.graph;
 
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.UndirectedGraph;
 import edu.uci.ics.jung.graph.util.EdgeType;
-import static junit.framework.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 public class UndirectedGraphWrapperTest {


### PR DESCRIPTION
- Requires fork of Jung2 from
  https://github.com/competent/jung2/tree/jung2-2_0_1-collections4
- The generic enabled Commons Collections library used in Jung2 is not
  fully compatible with Java 8, so porting to the Java8 compatible
  official Collections4 library
